### PR TITLE
Add new workflows

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,4 +1,4 @@
-name: ci-python
+name: ci
 
 on:
   workflow_call:
@@ -20,15 +20,8 @@ jobs:
         run: just lint-md
       - name: Lint Python files
         run: just lint-python
-
-      # Upload the docs if they built.
       - name: Lint the docs
         run: just docs
-      - name: Upload documentation for release
-        uses: actions/upload-artifact@v3
-        with:
-          name: docs
-          path: docs/build/html/
 
   test:
     runs-on: ubuntu-latest
@@ -44,40 +37,3 @@ jobs:
         run: poetry install
       - name: Run the unit tests
         run: just test
-
-  docs:
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
-    needs:
-      - lint
-      - test
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: docs
-          path: docs/build/html
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/build/html/
-
-  release:
-    needs:
-      - lint
-      - test
-      - docs
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-      - uses: actions/checkout@v3
-      - name: Get Changelog Entry
-        id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2
-      - name: Publish the release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          body: ${{ steps.changelog_reader.outputs.changes }}

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -1,4 +1,4 @@
-name: ci-rust
+name: ci
 
 on:
   workflow_call:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,0 +1,60 @@
+name: release
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: extractions/setup-just@v1
+      - uses: ts-graphviz/setup-graphviz@v1
+      - uses: Gr1N/setup-poetry@v8
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "poetry"
+      - name: Setup the project
+        run: poetry install
+      - name: Lint markdown files
+        run: just lint-md
+      - name: Lint Python files
+        run: just lint-python
+      - name: Build the docs
+        run: just docs
+      - name: Upload documentation for release
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: docs/build/html/
+
+  docs:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: docs/build/html
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html/
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - docs
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get Changelog Entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+      - name: Publish the release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: ${{ steps.changelog_reader.outputs.changes }}


### PR DESCRIPTION
Splits the Python workflows into 2 new workflows: ci and release.

The workflows also have been renamed to only have the name of their
goal, independently of the language used. This should simplify some
automation/configuration tasks.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
