### PR TITLE
Update Docker publish workflow

### DIFF
--- a/.github/workflows/docker-build-publish-ghcr.yml
+++ b/.github/workflows/docker-build-publish-ghcr.yml
@@ -2,6 +2,18 @@ name: docker-build-publish-ghcr
 
 on:
   workflow_call:
+    inputs:
+      push-to-ghcr:
+        description: "Publish the image to ghcr.io"
+        default: false
+        type: boolean
+      push-to-ecr:
+        description: "Publish the image to AWS ECR"
+        default: false
+        type: boolean
+    secrets:
+      github-role:
+        description: "ARN of the federated role to use to deploy from GitHub to AWS."
 
 jobs:
   build:
@@ -13,22 +25,39 @@ jobs:
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-      - name: Log in to the Container registry
+
+      - name: Log in to the GitHub Container Registry
+        if: inputs.push-to-ghcr
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS credentials
+        if: inputs.push-to-ecr
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.github-role }}
+          aws-region: us-west-2
+      - name: Login to Amazon ECR
+        if: inputs.push-to-ecr
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: |
+            name=ghcr.io/${{ github.repository }},enable=${{ inputs.push-to-ghcr }}
+            name=${{ steps.login-ecr.outputs.registry }}/${{ github.repository }},enable=${{ inputs.push-to-ecr}}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
+          platforms: linux/amd64,linux/arm64
+          push: ${{ inputs.push-to-ghcr || inputs.push-to-ecr }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adds the ability to build a Docker image and publish it to ghcr.io
and/or AWS ECR.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
