### PR TITLE
Fix ECR repository name

### DIFF
--- a/.github/workflows/docker-build-publish-ghcr.yml
+++ b/.github/workflows/docker-build-publish-ghcr.yml
@@ -51,10 +51,12 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        env:
+          REPO_NAME: ${GITHUB_REPOSITORY##*/}
         with:
           images: |
             name=ghcr.io/${{ github.repository }},enable=${{ inputs.push-to-ghcr }}
-            name=${{ steps.login-ecr.outputs.registry }}/${{ github.repository }},enable=${{ inputs.push-to-ecr}}
+            name=${{ steps.login-ecr.outputs.registry }}/${{ env.REPO_NAME }},enable=${{ inputs.push-to-ecr}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0


### PR DESCRIPTION
Removes the owner part of the provided repository name when building the ECR name.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
