### PR TITLE
Make Docker latest tag optional

### DIFF
--- a/.github/workflows/docker-build-publish-ghcr.yml
+++ b/.github/workflows/docker-build-publish-ghcr.yml
@@ -14,6 +14,10 @@ on:
       aws-region:
         description: "Specifies the AWS region to use"
         type: string
+      use-latest:
+        description: "Flag enabling the use of the 'latest' tag"
+        type: boolean
+        default: false
     secrets:
       github-role:
         description: "ARN of the federated role to use to deploy from GitHub to AWS."
@@ -59,6 +63,7 @@ jobs:
           images: |
             name=ghcr.io/${{ github.repository }},enable=${{ inputs.push-to-ghcr }}
             name=${{ steps.login-ecr.outputs.registry }}/${{ steps.repo-name.outputs.repo_name }},enable=${{ inputs.push-to-ecr}}
+          flavor: latest=${{ inputs.use-latest }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0


### PR DESCRIPTION
Adds a new input to enable the use of the latest tag.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
